### PR TITLE
Add ù and Ù in French language

### DIFF
--- a/data/fr
+++ b/data/fr
@@ -11,5 +11,7 @@ codepoints:
 - 192 # A with a grave
 - 194 # A with a circumflex
 - 198 # Capital letter ae
-- 376 # Capital Y-diaeresis
 - !ruby/range 200..203 # Accented E
+- 217 # Capital U with grave
+- 249 # lowercase u with grave
+- 376 # Capital Y-diaeresis


### PR DESCRIPTION
This commit adds `lowercase u with grave` and `capital U with grave` to French. These appear, for instance, in the word "où", meaning "where." It also rearranges the codepoints to maintain numerical order.
