### PR TITLE
Remove « and » from Finnish

### DIFF
--- a/data/fi
+++ b/data/fi
@@ -5,8 +5,6 @@ native_name: Suomi
 codepoints:
 - !ruby/range 65..90     # A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
 - !ruby/range 97..122    # a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
-- 171                    # «
-- 187                    # »
 - !ruby/range 196..197   # Ä,Å
 - 214                    # Ö
 - !ruby/range 228..229   # ä,å

--- a/lib/speakeasy.rb
+++ b/lib/speakeasy.rb
@@ -1,5 +1,5 @@
 require 'speakeasy/language'
 
 module Speakeasy
-  VERSION = "0.1.23"
+  VERSION = "0.1.24"
 end


### PR DESCRIPTION
## Why?

See https://unicode-org.atlassian.net/browse/CLDR-14842 - there is a `»` without a matching `«` in the CLDR data. We fixed it in https://github.com/typekit/speakeasy/pull/31 by adding `«` but after consideration it looks like neither should be there at all.

## What?

Remove « and » from Finnish. Bump the Speakeasy version