### PR TITLE
Fix ranges and add spec for testing that the ranges are valid.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 gem "rake"
 
+gemspec
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+PATH
+  remote: .
+  specs:
+    speakeasy (0.1.31)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rake
+  rspec (>= 3.5.0)
+  speakeasy!
+
+BUNDLED WITH
+   2.3.5

--- a/data/Guru
+++ b/data/Guru
@@ -19,4 +19,4 @@ codepoints:
 - 2641
 - !ruby/range 2649..2652
 - 2654
-- !ruby/range 2662..167
+- !ruby/range 2662..2676

--- a/data/ta
+++ b/data/ta
@@ -9,7 +9,7 @@ codepoints:
 - !ruby/range 2962..2965
 - !ruby/range 2969..2970
 - 2972
-- !ruby/range 2974..2973
+- !ruby/range 2973..2974
 - !ruby/range 2979..2980
 - !ruby/range 2984..2986
 - !ruby/range 2990..3001

--- a/speakeasy.gemspec
+++ b/speakeasy.gemspec
@@ -54,6 +54,8 @@ Gem::Specification.new do |s|
   ## those that are only needed during development
   #s.add_development_dependency('DEVDEPNAME', [">= 1.1.0", "< 2.0.0"])
 
+  s.add_development_dependency('rspec', [">= 3.5.0"])
+
   ## Leave this section as-is. It will be automatically generated from the
   ## contents of your Git repository via the gemspec task. DO NOT REMOVE
   ## THE MANIFEST COMMENTS, they are used as delimiters by the task.

--- a/spec/language_spec.rb
+++ b/spec/language_spec.rb
@@ -1,7 +1,7 @@
 require File.dirname(__FILE__) + "/spec_helper"
 
 describe "A Language" do
-  SupportedLanguages = 15
+  SupportedLanguages = 55
 
   it "can list the supported language ids" do
     Speakeasy::Language.supported_language_ids.size.should == SupportedLanguages
@@ -13,6 +13,18 @@ describe "A Language" do
 
   it "can iterate over all supported languages" do
     Speakeasy::Language.each.to_a.size.should == SupportedLanguages
+  end
+
+  it "contains valid code point ranges" do
+    Speakeasy::Language.each do |lang|
+      codepoints = lang.instance_variable_get(:@data)["codepoints"]
+
+      codepoints.each do |c|
+        if c.is_a?(Range)
+          expect(c.to_a).not_to be_empty
+        end
+      end
+    end
   end
 
   context "(German)" do


### PR DESCRIPTION
:wave: Some of the ranges in Gurmukhi and Tamil are incorrect.

Gurmukhi: 2662..167 (this appears to be a typo; replaced with 2676 per [Wikipedia](https://en.wikipedia.org/wiki/Gurmukhi_(Unicode_block)))
Tamil: 2974..2973 (this appears to have been typed in an incorrect order)

In both cases the Range returns an empty array:

```ruby
r = 2662..167
puts(r.to_a) # nil
```

This means the code points in that range are not included for both languages. This PR fixes the ranges and adds a spec to check for these cases, so this does not happen in the future. On a related note, it looks like the test suite hasn't been updated/running for a while, so I also updated that to make sure nothing else was broken.